### PR TITLE
Append 'npx' prior to 'create-react-app --version'

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The remainder of this document contains a tutorial on creating a React app (usin
 3. An adequate version of [`create-react-app`](https://github.com/facebookincubator/create-react-app) is installed. Here's the adequate version I use:
 
     ```sh
-    $ create-react-app --version
+    $ npx create-react-app --version
     1.3.1
     ```
 


### PR DESCRIPTION
Using the suggested command did not get the version for create-react-app on my machine.

```
create-react-app --version                                                                   
'create-react-app' is not recognized as an internal or external command, operable program or batch file.   
```

```
npx create-react-app --version                                                               
 4.0.3                                                                                                                                                                                                                                          
```