### PR TITLE
Step 6: Reference GitHub repository using SSH instead of HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ At this point, the  React app's `package.json` file includes deployment scripts.
     You can do that by issuing a command in this format: 
     
     ```shell
-    $ git remote add origin https://github.com/{username}/{repo-name}.git
+    $ git remote add origin git@github.com:{username}/{repo-name}.git
     ```
     
     To customize that command for your situation, replace `{username}` with your GitHub username and replace `{repo-name}` with the name of the GitHub repository you created in Step 1.
@@ -159,7 +159,7 @@ At this point, the  React app's `package.json` file includes deployment scripts.
     In my case, I'll run:
 
     ```shell
-    $ git remote add origin https://github.com/gitname/react-gh-pages.git
+    $ git remote add origin git@github.com:gitname/react-gh-pages.git
     ```
 
     > That command tells Git where I want it to push things whenever I—or the `gh-pages` npm package acting on my behalf—issue the `$ git push` command from within this local Git repository.


### PR DESCRIPTION
Due to the privacy update on GitHub, the normal sign-in with username and password feature has been deprecated. By following step six and adding HTTP remote as an upstream branch for deploying the app by `gh-pages`, the process is going to be terminated and you'll see an error from GitHub.